### PR TITLE
chore: Raise Go to 1.27.1 and pin staticcheck.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thenativeweb/esdm
 
-go 1.26.2
+go 1.27.1
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
@@ -21,7 +21,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
 	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
-	honnef.co/go/tools v0.6.1 // indirect
+	honnef.co/go/tools v0.8.1 // indirect
 )
 
 tool honnef.co/go/tools/cmd/staticcheck

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -39,3 +40,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.6.1 h1:R094WgE8K4JirYjBaOpz/AvTyUu/3wbmAoskKN/pxTI=
 honnef.co/go/tools v0.6.1/go.mod h1:3puzxxljPCe8RGJX7BIy1plGbxEOZni5mR2aXe3/uk4=
+honnef.co/go/tools v0.8.1 h1:+JKf3xJ1ni4CwrhVg4/pqsfPGP6vNAXcKbMXJodYx3w=
+honnef.co/go/tools v0.8.1/go.mod h1:XA+OnlRA9EDh/ukGvXMNSZNKGwFQJ+5dER0ioUkOxks=


### PR DESCRIPTION
## Why

`staticcheck@latest` turned an upstream release into a red pipeline across three repositories in this organization: staticcheck v0.8.1 began requiring Go >= 1.26, and every branch went red at once without anything in those repositories having changed. A tool version that can move on its own is the problem, not the cure.

This is the organization-wide sweep that follows from it.

## What changed

- **Go moves to 1.27.1.** Not to 1.26: that is exactly staticcheck's current floor, so the next release raising it would put us right back in this position.
- **staticcheck is pinned at v0.8.1** as a tool dependency, run via `go tool staticcheck`. It still gets updated — Dependabot treats it like any other Go dependency — but in a pull request of its own, with a pipeline behind it, instead of in the middle of an unrelated one.
- Where a `Dockerfile` builds with a `golang` image, it moves along too. Otherwise the image would build with a Go older than the module declares.

## Verified

Locally, with this repository's own analyze target rather than a generic invocation — several repositories pass their own flags, and one excludes generated code:

- `make analyze` (or `make lint`) → exit 0
- `go build ./...` → clean
- `go test ./...` → see below

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2SKRAbkaRS7VvzZRaiRGi
